### PR TITLE
demo: PDF Issuance & Individual fields verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,14 @@
   },
   "dependencies": {
     "@cord.network/sdk": "0.9.6-5",
-    "dotenv": "^16.4.5"
+    "doken-precomputer": "^0.0.4",
+    "dotenv": "^16.4.5",
+    "inquirer": "^12.9.0",
+    "pdf-lib": "^1.17.1",
+    "pdf-parse": "^1.1.1",
+    "pdf2json": "^3.2.0",
+    "tesseract": "^0.0.3",
+    "tesseract.js": "5"
   },
   "devDependencies": {
     "moment": "^2.30.1",

--- a/src/pdf-flow/pdf-issuer/generatePdf.ts
+++ b/src/pdf-flow/pdf-issuer/generatePdf.ts
@@ -1,0 +1,71 @@
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { hash } from './utils/hash';
+import { computeEntryDokenId } from 'doken-precomputer';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { GLOBAL_REGISTRY_ID, GLOBAL_ISSUER_ADDRESS } from './index';
+
+type FieldData = {
+  name: string;
+  rollNumber: string;
+  course: string;
+  issueDate: string;
+};
+
+export async function generatePdfWithMetadata(
+  fields: FieldData,
+  registryId: string = GLOBAL_REGISTRY_ID,
+  accountAddress: string = GLOBAL_ISSUER_ADDRESS
+) {
+
+  const fieldHashes: Record<string, string> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    fieldHashes[key] = hash(value);
+  }
+
+  const combinedHashInput = Object.values(fieldHashes).join('');
+  /* TODO: Hash student-id/roll-number later */
+  const txHash = hash(combinedHashInput);
+
+  const provider = new WsProvider('ws://127.0.0.1:9944'); // Adjust to your CORD endpoint
+  const api = await ApiPromise.create({ provider });
+
+  const entryId = await computeEntryDokenId(api, txHash, registryId, accountAddress);
+  await api.disconnect();
+
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage();
+  const { height } = page.getSize();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const fontSize = 14;
+
+  const lines = [
+    `Name: ${fields.name}`,
+    `Roll Number: ${fields.rollNumber}`,
+    `Course: ${fields.course}`,
+    `Issue Date: ${fields.issueDate}`,
+  ];
+
+  let y = height - 50;
+  for (const line of lines) {
+    page.drawText(line, { x: 50, y, size: fontSize, font, color: rgb(0, 0, 0) });
+    y -= 24;
+  }
+
+  pdfDoc.setTitle(`EntryID: ${entryId}`);
+  pdfDoc.setSubject('Transcript issued by Issuer');
+  pdfDoc.setAuthor('CORD Network Issuer App');
+    pdfDoc.setKeywords(
+    Object.entries(fieldHashes).map(([k, v]) => `${k}:${v}`)
+    );
+
+  /* Write to chain */
+  /* Create a registry-entry with digest as the roll-no, blob with field hashes of all individual data */
+
+  const pdfBytes = await pdfDoc.save();
+  if (!existsSync('./output')) mkdirSync('./output');
+  writeFileSync('./output/transcript.pdf', pdfBytes);
+
+  console.log('📄 PDF saved at ./output/transcript.pdf');
+  console.log('🧾 EntryID:', entryId);
+}

--- a/src/pdf-flow/pdf-issuer/index.ts
+++ b/src/pdf-flow/pdf-issuer/index.ts
@@ -1,0 +1,28 @@
+import inquirer from 'inquirer';
+import { generatePdfWithMetadata } from './generatePdf';
+
+/* Make these data modular, from chain */
+/* Create a account derived from Alice, and a registry */
+export const GLOBAL_REGISTRY_ID = "Tt6fvp5LP3tEmNivbXu28Tm8RWnwbCZTpsXg2JdTUGWRcEbtYTwAVEz"
+export const GLOBAL_ISSUER_ADDRESS = "3ukwFjWy69cLL6ab5LAHMKfygau6oJS3xeDbKKwbsRVnKeZA"
+
+async function main() {
+  const answers = await inquirer.prompt([
+    { type: 'input', name: 'name', message: 'Student Name:' },
+    { type: 'input', name: 'rollNumber', message: 'Roll Number:' },
+    { type: 'input', name: 'course', message: 'Course:' },
+    { type: 'input', name: 'issueDate', message: 'Issue Date (YYYY-MM-DD):' }
+  ]);
+
+  const fieldData = {
+    name: answers.name,
+    rollNumber: answers.rollNumber,
+    course: answers.course,
+    issueDate: answers.issueDate,
+  };
+
+  await generatePdfWithMetadata(fieldData, GLOBAL_REGISTRY_ID, GLOBAL_ISSUER_ADDRESS);
+  console.log("✅ PDF generated with embedded metadata. Check /output folder.");
+}
+
+main();

--- a/src/pdf-flow/pdf-issuer/utils/hash.ts
+++ b/src/pdf-flow/pdf-issuer/utils/hash.ts
@@ -1,0 +1,6 @@
+import { blake2AsHex } from '@polkadot/util-crypto';
+
+/* using blake here so we maintain uniformity on chain and off chain */
+export function hash(data: string): string {
+  return blake2AsHex(data)
+}

--- a/src/pdf-flow/pdf-verifier/extractVisibleTextTest.ts
+++ b/src/pdf-flow/pdf-verifier/extractVisibleTextTest.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import pdfParse from 'pdf-parse';
+import { createWorker } from 'tesseract.js';
+
+async function extractVisibleTextWithPDFParse(filePath: string): Promise<string> {
+  try {
+    const fileBuffer = fs.readFileSync(filePath);
+    const data = await pdfParse(fileBuffer, { max: 0 });
+    console.log(`PDF info for ${filePath}:`, data.info);
+    if (!data.text.trim()) {
+      console.warn(`⚠️  No text extracted with pdf-parse from ${filePath}. Falling back to OCR.`);
+      return '';
+    }
+    return data.text;
+  } catch (error) {
+    console.error(`❌ pdf-parse error for ${filePath}: ${error.message}`);
+    return '';
+  }
+}
+
+async function extractVisibleTextWithOCR(filePath: string): Promise<string> {
+  try {
+    const pdfText = await extractVisibleTextWithPDFParse(filePath);
+    if (pdfText.trim()) {
+      return pdfText; 
+    }
+
+    console.log(`🔄 Attempting OCR with tesseract.js for ${filePath}`);
+    const worker = await createWorker('eng'); 
+    const { data: { text: ocrText } } = await worker.recognize(filePath);
+    await worker.terminate();
+
+    if (!ocrText.trim()) {
+      console.warn(`No text extracted with OCR from ${filePath}.`);
+    }
+    return ocrText;
+  } catch (error) {
+    console.error(`Error extracting text from ${filePath}: ${error.message}`);
+    return '';
+  }
+}
+
+async function testExtractVisibleText(filePath: string) {
+  const text = await extractVisibleTextWithOCR(filePath);
+  console.log(`Visible text for ${filePath}:`, JSON.stringify(text));
+  console.log(`Lines for ${filePath}:`, text.split('\n').map(line => line.trim()).filter(line => line));
+}
+
+testExtractVisibleText('./output/transcript.pdf').catch(console.error);
+testExtractVisibleText('./output/resume.pdf').catch(console.error);

--- a/src/pdf-flow/pdf-verifier/utils/hash.ts
+++ b/src/pdf-flow/pdf-verifier/utils/hash.ts
@@ -1,0 +1,6 @@
+import { blake2AsHex } from '@polkadot/util-crypto';
+
+/* using blake here so we maintain uniformity on chain and off chain */
+export function hash(data: string): string {
+  return blake2AsHex(data)
+}

--- a/src/pdf-flow/pdf-verifier/verifier.ts
+++ b/src/pdf-flow/pdf-verifier/verifier.ts
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import { exec } from 'child_process';
+import util from 'util';
+import pdfParse from 'pdf-parse';
+import { hash } from './utils/hash';
+
+const execPromise = util.promisify(exec);
+
+async function extractMetadata(filePath: string) {
+  try {
+    /* exiftool suits better and easier to extract for now */
+    const { stdout } = await execPromise(`exiftool -j ${filePath}`);
+    const metadata = JSON.parse(stdout)[0];
+
+    const title = metadata.Title ?? '';
+    let keywords: string[] = [];
+
+    if (Array.isArray(metadata.Keywords)) {
+      keywords = metadata.Keywords.map(s => s.trim());
+    } else if (typeof metadata.Keywords === 'string') {
+      keywords = metadata.Keywords.split(/,\s*/).map(s => s.trim());
+    }
+
+    if (!title || keywords.length === 0) {
+      console.warn('⚠️  No valid metadata found.');
+      return { entryId: '', fieldHashes: {} };
+    }
+
+    const fieldHashes: Record<string, string> = {};
+    for (const pair of keywords) {
+      const parts = pair.split(':').map(s => s.trim());
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        console.warn(`⚠️  Invalid metadata pair: ${pair}`);
+        continue;
+      }
+      const [key, hash] = parts;
+      /* Validate BLAKE2b hash (66 characters, starts with 0x, followed by 64 hex chars), not required for now */
+      if (/^0x[0-9a-fA-F]{64}$/.test(hash)) {
+        fieldHashes[key] = hash;
+      } else {
+        console.warn(`⚠️  Invalid hash for ${key}: ${hash}`);
+      }
+    }
+
+    const entryId = title.replace('EntryID: ', '').trim();
+    return { entryId, fieldHashes };
+  } catch (error) {
+    console.error(`❌ Error extracting metadata: ${error.message}`);
+    return { entryId: '', fieldHashes: {} };
+  }
+}
+
+async function extractVisibleText(filePath: string) {
+  try {
+    const fileBuffer = fs.readFileSync(filePath);
+    const data = await pdfParse(fileBuffer, { max: 0 }); 
+    return data.text;
+  } catch (error) {
+    console.error(`❌ Error extracting text: ${error.message}`);
+    return '';
+  }
+}
+
+async function verifyTranscript(filePath: string) {
+  try {
+    const { entryId, fieldHashes } = await extractMetadata(filePath);
+    const visibleText = await extractVisibleText(filePath);
+
+    if (!entryId || Object.keys(fieldHashes).length === 0) {
+      console.error('❌ No valid metadata to verify.');
+      return [];
+    }
+
+    console.log('Visible text:', JSON.stringify(visibleText));
+    console.log(`Verifying EntryID: ${entryId}`);
+    console.log('Metadata fieldHashes:', fieldHashes);
+
+    const lines = visibleText.split('\n').map(line => line.trim()).filter(line => line);
+    console.log('Lines:', lines);
+
+    const results: string[] = [];
+
+    for (const [field, expectedHash] of Object.entries(fieldHashes)) {
+      console.log(`🔍 Verifying field: ${field}`);
+
+      const normalizedField = field.toLowerCase().replace(/\s+/g, '');
+      const match = lines.find(line => {
+        const normalizedLine = line.toLowerCase().replace(/\s+/g, '');
+        return normalizedLine.startsWith(normalizedField + ':');
+      });
+
+      if (!match) {
+        console.log(`${field} not found in visible content`);
+        results.push(`${field} not found in visible content`);
+        continue;
+      }
+
+      const actualValue = match.substring(match.indexOf(':') + 1).trim();
+      const actualHash = hash(actualValue);
+
+      if (actualHash === expectedHash) {
+        console.log(`${field} verified (value: ${actualValue})`);
+        results.push(`${field} verified`);
+      } else {
+        console.log(`${field} tampered (expected: ${expectedHash}, got: ${actualHash}, value: ${actualValue})`);
+        results.push(`${field} tampered (expected: ${expectedHash}, got: ${actualHash})`);
+      }
+    }
+
+    console.log('\nVerification Summary:\n' + results.join('\n'));
+    return results;
+  } catch (error) {
+    console.error(`Verification failed: ${error.message}`);
+    return [];
+  }
+}
+
+verifyTranscript('./output/transcript.pdf').catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cord.network/types@npm:0.9.6-4":
+  version: 0.9.6-4
+  resolution: "@cord.network/types@npm:0.9.6-4"
+  dependencies:
+    "@polkadot/api": "npm:^15.9.1"
+    "@polkadot/keyring": "npm:^13.4.3"
+    "@polkadot/types": "npm:^15.9.1"
+    "@polkadot/util": "npm:^13.4.3"
+    "@polkadot/util-crypto": "npm:^13.4.3"
+  checksum: a06c493e6c8cdda474caa2919024062421774c897837fe345cbcf0a0e08c952f1f6266bf408b6f8f24a0dc88d0d5230824399486a205131ab3e183300aae9781
+  languageName: node
+  linkType: hard
+
 "@cord.network/types@npm:0.9.6-5":
   version: 0.9.6-5
   resolution: "@cord.network/types@npm:0.9.6-5"
@@ -358,6 +371,231 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/checkbox@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@inquirer/checkbox@npm:4.2.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/figures": "npm:^1.0.13"
+    "@inquirer/type": "npm:^3.0.8"
+    ansi-escapes: "npm:^4.3.2"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 9d0371f946d3866f5192debb48ef7567e63d0bbed3177e3fbba83c830eea267761a7efb6223bfa5e7674415a7040f628314263ba4165e6e6e374335022d87659
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.14":
+  version: 5.1.14
+  resolution: "@inquirer/confirm@npm:5.1.14"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 12f49e8d1564c77c290163e87c9a256cfc087eab0c096738c73b03aa3d59a98c233fb9fb3692f162d67f923d120a4aa8ef819f75d979916dc13456f726c579d1
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.1.15":
+  version: 10.1.15
+  resolution: "@inquirer/core@npm:10.1.15"
+  dependencies:
+    "@inquirer/figures": "npm:^1.0.13"
+    "@inquirer/type": "npm:^3.0.8"
+    ansi-escapes: "npm:^4.3.2"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 3214dfa882f17e3d9cdd45fc73f9134b90e3d685f8285f7963d836fe25f786d8ecf9c16d2710fc968b77da40508fa74466d5ad90c5466626037995210b946b12
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.15":
+  version: 4.2.15
+  resolution: "@inquirer/editor@npm:4.2.15"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+    external-editor: "npm:^3.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 81c524c3a80b4c75565bb316b2f06b055d374f7f79cc1140528a966f0dd2ca9099bb18466203125db52092b2c9bab2e4f17e81e40fb5ca204fdd939f07b02ea4
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.17":
+  version: 4.0.17
+  resolution: "@inquirer/expand@npm:4.0.17"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: b5335de9d2c49ea4980fc2d0be1568cc700eb1b9908817efc19cccec78d3ad412d399de1c2562d8b8ffafe3fbc2946225d853c8bb2d27557250fea8ca5239a7f
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "@inquirer/figures@npm:1.0.13"
+  checksum: 23700a4a0627963af5f51ef4108c338ae77bdd90393164b3fdc79a378586e1f5531259882b7084c690167bf5a36e83033e45aca0321570ba810890abe111014f
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@inquirer/input@npm:4.2.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: d1bf680084703f42a2f29d63e35168b77e714dfdc666ce08bc104352385c19f22d65a8be7a31361a83a4a291e2bb07a1d20f642f5be817ac36f372e22196a37a
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.17":
+  version: 3.0.17
+  resolution: "@inquirer/number@npm:3.0.17"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: f77efe93c4c8e3efdc58a92d184468f20c351846cc89f5def40cdcb851e8800719b4834d811bddb196d38a0a679c06ad5d33ce91e68266b4a955230ce55dfa52
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.17":
+  version: 4.0.17
+  resolution: "@inquirer/password@npm:4.0.17"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+    ansi-escapes: "npm:^4.3.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 7b2773bb11ecdb2ba984daf6a089e7046ecdfa09a6ad69cd41e3eb87cbeb57c5cc4f6ae17ad9ca817457ea5babac622bf7ffbdc7013c930bb95d56a8b479f3ff
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "@inquirer/prompts@npm:7.8.0"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.2.0"
+    "@inquirer/confirm": "npm:^5.1.14"
+    "@inquirer/editor": "npm:^4.2.15"
+    "@inquirer/expand": "npm:^4.0.17"
+    "@inquirer/input": "npm:^4.2.1"
+    "@inquirer/number": "npm:^3.0.17"
+    "@inquirer/password": "npm:^4.0.17"
+    "@inquirer/rawlist": "npm:^4.1.5"
+    "@inquirer/search": "npm:^3.1.0"
+    "@inquirer/select": "npm:^4.3.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 870496b7e9c5aa09198f47e95b5e73af4363c5736bfd1ef0e4722859cfd0dff56e0302e15bc3f7dcc4af7efb4654a7f6c3eb0351deb4a09f2094688c86136f55
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "@inquirer/rawlist@npm:4.1.5"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/type": "npm:^3.0.8"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 6eed0f8a4d223bbc4f8f1b6d21e3f0ca1d6398ea782924346b726ff945b9bcb30a1f3a4f3a910ad7a546a4c11a3f3ff1fa047856a388de1dc29190907f58db55
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@inquirer/search@npm:3.1.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/figures": "npm:^1.0.13"
+    "@inquirer/type": "npm:^3.0.8"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: e53b9a61bb8066d826e2b1829e63ed6a5926b7d3a55f01f66d6023cd062156063a5af3ba5c077ea5f826f755e07b4d2ea8ee867837ce7ee8c23a8b86a71fc472
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/select@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/figures": "npm:^1.0.13"
+    "@inquirer/type": "npm:^3.0.8"
+    ansi-escapes: "npm:^4.3.2"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: febce759b99548eddea02d72611e9302b10d6b3d2cb44c18f7597b79ab96c8373ba775636b2a764f57be13d08da3364ad48c3105884f19082ea75eade69806dd
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@inquirer/type@npm:3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 1171bffb9ea0018b12ec4f46a7b485f7e2a328e620e89f3b03f2be8c25889e5b9e62daca3ea10ed040a71d847066c4d9879dc1fea8aa5690ebbc968d3254a5ac
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -407,6 +645,24 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 162b4a0b8705cd6f5c2470b851d1dc6cd228c86d2170e1769d738c1fbb69a87160901411c3c035331e9e99db72f1f1099a8b734bf1637cc32b9a5be1660e4e1e
+  languageName: node
+  linkType: hard
+
+"@pdf-lib/standard-fonts@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@pdf-lib/standard-fonts@npm:1.0.0"
+  dependencies:
+    pako: "npm:^1.0.6"
+  checksum: c683adfb764cd235a8370a0c1d5a8d7e90e3499ad33cdecfb92e4d48b0d36cfd038e3a875ebd0937a5646ee1578d793ab98f9c374be360c9a05d2699c1caedf4
+  languageName: node
+  linkType: hard
+
+"@pdf-lib/upng@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@pdf-lib/upng@npm:1.0.1"
+  dependencies:
+    pako: "npm:^1.0.10"
+  checksum: 9c300c513c1089e561c0cccac01f396a24efb9b0e9c922a39248cb09dfced70c05b9facdfce11a7f22cbedb4129593630a18111b90a57ef34ea4c3df98f2ac1d
   languageName: node
   linkType: hard
 
@@ -1002,6 +1258,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -1036,6 +1301,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
+"bmp-js@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "bmp-js@npm:0.1.0"
+  checksum: c651bd5936dcf8d67900050fac14dcbe30baf87c3d21c58f4934fcdf46172e152a87d8c0c3ca25caa2b4b2c7780ef3b5fcc6cd20afd8f0351856cadb1bef9694
   languageName: node
   linkType: hard
 
@@ -1118,6 +1390,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -1129,6 +1408,13 @@ __metadata:
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
   checksum: 1f90262d5f6230a17e27d0c190b09d47ebe7efdd76a03b5a1127863f7b3c9aec4c3e6c8bb3a7bbf81d553d56a1fd35728f5a8ef4c63f867ac8d690109742a8c1
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
@@ -1153,8 +1439,15 @@ __metadata:
   resolution: "cord-demo-scripts@workspace:."
   dependencies:
     "@cord.network/sdk": "npm:0.9.6-5"
+    doken-precomputer: "npm:^0.0.4"
     dotenv: "npm:^16.4.5"
+    inquirer: "npm:^12.9.0"
     moment: "npm:^2.30.1"
+    pdf-lib: "npm:^1.17.1"
+    pdf-parse: "npm:^1.1.1"
+    pdf2json: "npm:^3.2.0"
+    tesseract: "npm:^0.0.3"
+    tesseract.js: "npm:5"
     tsx: "npm:^4.19.1"
   languageName: unknown
   linkType: soft
@@ -1189,10 +1482,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^3.1.0":
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
+  dependencies:
+    ms: "npm:^2.1.1"
+  checksum: 37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.1":
   version: 2.0.3
   resolution: "detect-libc@npm:2.0.3"
   checksum: 88095bda8f90220c95f162bf92cad70bd0e424913e655c20578600e35b91edc261af27531cf160a331e185c0ced93944bc7e09939143225f56312d7fd800fdb7
+  languageName: node
+  linkType: hard
+
+"doken-precomputer@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "doken-precomputer@npm:0.0.4"
+  dependencies:
+    "@cord.network/types": "npm:0.9.6-4"
+    "@polkadot/api": "npm:^15.9.1"
+    "@polkadot/types": "npm:^15.9.1"
+    "@polkadot/util": "npm:^13.4.3"
+    "@polkadot/util-crypto": "npm:^13.4.3"
+  checksum: 9433919e3b62cf35d49877cab43b89f35ba398fb957fb9c5d87b99ff759d962b4e1e6ff4d9dc92531efeeca578e9fc5dc43f106e177c6c46ade217ca066b76c5
   languageName: node
   linkType: hard
 
@@ -1344,6 +1659,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"external-editor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
 "fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
   version: 3.2.0
   resolution: "fetch-blob@npm:3.2.0"
@@ -1468,12 +1794,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"idb-keyval@npm:^6.2.0":
+  version: 6.2.2
+  resolution: "idb-keyval@npm:6.2.2"
+  checksum: b52f0d2937cc2ec9f1da536b0b5c0875af3043ca210714beaffead4ec1f44f2ad322220305fd024596203855224d9e3523aed83e971dfb62ddc21b5b1721aeef
   languageName: node
   linkType: hard
 
@@ -1491,6 +1833,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^12.9.0":
+  version: 12.9.0
+  resolution: "inquirer@npm:12.9.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.15"
+    "@inquirer/prompts": "npm:^7.8.0"
+    "@inquirer/type": "npm:^3.0.8"
+    ansi-escapes: "npm:^4.3.2"
+    mute-stream: "npm:^2.0.0"
+    run-async: "npm:^4.0.5"
+    rxjs: "npm:^7.8.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: e00ca591d620fedfa10ce186d3714d475391a130fc264e08f1e5bc81d6549881f79efc48f3303b7b19aa2fb37fcb3d9a48faa35eb339c8ed2360e9e6099f2fdb
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -1498,6 +1860,13 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+  languageName: node
+  linkType: hard
+
+"is-electron@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "is-electron@npm:2.2.2"
+  checksum: 327bb373f7be01b16cdff3998b5ddaa87d28f576092affaa7fe0659571b3306fdd458afbf0683a66841e7999af13f46ad0e1b51647b469526cd05a4dd736438a
   languageName: node
   linkType: hard
 
@@ -1512,6 +1881,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 85fee098ae62ba6f1e24cf22678805473c7afd0fb3978a3aa260e354cb7bcb3a5806cf0a98403188465efedec41ab4348e8e4e79305d409601323855b3839d4d
+  languageName: node
+  linkType: hard
+
+"is-url@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "is-url@npm:1.2.4"
+  checksum: 0157a79874f8f95fdd63540e3f38c8583c2ef572661cd0693cda80ae3e42dfe8e9a4a972ec1b827f861d9a9acf75b37f7d58a37f94a8a053259642912c252bc3
   languageName: node
   linkType: hard
 
@@ -1714,10 +2090,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "ms@npm:2.1.3"
+  checksum: d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
 "multiformats@npm:^9.0.0":
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: 1fdb34fd2fb085142665e8bd402570659b50a5fae5994027e1df3add9e1ce1283ed1e0c2584a5c63ac0a58e871b8ee9665c4a99ca36ce71032617449d48aa975
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
   languageName: node
   linkType: hard
 
@@ -1743,6 +2133,27 @@ __metadata:
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
   checksum: 5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
+"node-ensure@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "node-ensure@npm:0.0.0"
+  checksum: 7af391aee024a8b7df77c239ed8b90417e3f2539824fa06b60f243ce14c75ee455766464c7c3ba9407d5b1e4d1d74ed5cf5f8af10c67b0fc05aa6e29f5d2462b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 
@@ -1801,12 +2212,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"opencollective-postinstall@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "opencollective-postinstall@npm:2.0.3"
+  bin:
+    opencollective-postinstall: index.js
+  checksum: 8a0104a218bc1afaae943f0af378461eeb2836f9848bad872bbd067ec5d1d9791636f307454ab77d0746f10341366f295384656a340ebdb87a2585058e8567e5
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
+  languageName: node
+  linkType: hard
+
 "p-map@npm:^4.0.0":
   version: 4.0.0
   resolution: "p-map@npm:4.0.0"
   dependencies:
     aggregate-error: "npm:^3.0.0"
   checksum: 592c05bd6262c466ce269ff172bb8de7c6975afca9b50c975135b974e9bdaafbfe80e61aaaf5be6d1200ba08b30ead04b88cfa7e25ff1e3b93ab28c9f62a2c75
+  languageName: node
+  linkType: hard
+
+"pako@npm:^1.0.10, pako@npm:^1.0.11, pako@npm:^1.0.6":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
   languageName: node
   linkType: hard
 
@@ -1824,6 +2258,37 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: d723777fbf9627f201e64656680f66ebd940957eebacf780e6cce1c2919c29c116678b2d7dbf8821b3a2caa758d125f4444005ccec886a25c8f324504e48e601
+  languageName: node
+  linkType: hard
+
+"pdf-lib@npm:^1.17.1":
+  version: 1.17.1
+  resolution: "pdf-lib@npm:1.17.1"
+  dependencies:
+    "@pdf-lib/standard-fonts": "npm:^1.0.0"
+    "@pdf-lib/upng": "npm:^1.0.1"
+    pako: "npm:^1.0.11"
+    tslib: "npm:^1.11.1"
+  checksum: a9489a402880dacd1389a3e14ff8f6139d58e3bc82f26b0fcbd0798b841aee6ccb7fcfab0992b574e57b40404ced0330a7170b3c6467363461a9df5d9daec489
+  languageName: node
+  linkType: hard
+
+"pdf-parse@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pdf-parse@npm:1.1.1"
+  dependencies:
+    debug: "npm:^3.1.0"
+    node-ensure: "npm:^0.0.0"
+  checksum: cba2b6ddfbfa73d94ff0cd342cbe8ef2ef0501863ada687eddf99487a4d06766e00fc44525c40cef3b01f04376cb99d5873ab789bd3e2379a28c3ae5377f3298
+  languageName: node
+  linkType: hard
+
+"pdf2json@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "pdf2json@npm:3.2.0"
+  bin:
+    pdf2json: bin/pdf2json.js
+  checksum: affc3ddc7ba7234bf5ba0cb8aca19b75fbc9e8ddfe5e8139396804b5bf0ec84e262569d53c181f096b7e05c96c3efcdf4787a0874dd69320905db3679a3e19b2
   languageName: node
   linkType: hard
 
@@ -1851,6 +2316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.13.3":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 12b069dc774001fbb0014f6a28f11c09ebfe3c0d984d88c9bced77fdb6fedbacbca434d24da9ae9371bfbf23f754869307fb51a4c98a8b8b18e5ef748677ca24
+  languageName: node
+  linkType: hard
+
 "resolve-pkg-maps@npm:^1.0.0":
   version: 1.0.0
   resolution: "resolve-pkg-maps@npm:1.0.0"
@@ -1865,6 +2337,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-async@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "run-async@npm:4.0.5"
+  checksum: f6269ad515fe390ed2da8fed07ca9e5033cb97aa7228b871915f4b12d5ad07bcbbfef70e1a6f8032be0609e8284f565f0ac76c5ffb48e5db3ec1565b4c8f5217
+  languageName: node
+  linkType: hard
+
 "rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
@@ -1874,7 +2353,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"rxjs@npm:^7.8.2":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 1fcd33d2066ada98ba8f21fcbbcaee9f0b271de1d38dc7f4e256bfbc6ffcdde68c8bfb69093de7eeb46f24b1fb820620bf0223706cff26b4ab99a7ff7b2e2c45
+  languageName: node
+  linkType: hard
+
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -1915,7 +2403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -2029,6 +2517,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tesseract.js-core@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "tesseract.js-core@npm:5.1.1"
+  checksum: 9324277aa1598e0707ddbc175d4312fb7b4569e3fc42adbb42a5a3a747b5711a83c810c597b375585ec3261df31270730a146ab61c63fd16472a21867472eb31
+  languageName: node
+  linkType: hard
+
+"tesseract.js@npm:5":
+  version: 5.1.1
+  resolution: "tesseract.js@npm:5.1.1"
+  dependencies:
+    bmp-js: "npm:^0.1.0"
+    idb-keyval: "npm:^6.2.0"
+    is-electron: "npm:^2.2.2"
+    is-url: "npm:^1.2.4"
+    node-fetch: "npm:^2.6.9"
+    opencollective-postinstall: "npm:^2.0.3"
+    regenerator-runtime: "npm:^0.13.3"
+    tesseract.js-core: "npm:^5.1.1"
+    wasm-feature-detect: "npm:^1.2.11"
+    zlibjs: "npm:^0.3.1"
+  checksum: 46dd9c22c7c86d065c6fab07cdcc10e455c928e9d218e9e2a475eca4fc865bf60b052b3dc3503996fd195763184fb7deb2793083c84c869a6681e53d0329af36
+  languageName: node
+  linkType: hard
+
+"tesseract@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "tesseract@npm:0.0.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 06e074dddfbfb2c31b29247f7ad51fa19fe59923555c1e40050eee4b82fee490955d1c3e71b08ba76e015fdddcf09e45e39bf203d55c23af4708483807f1de8f
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.11.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.1.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
@@ -2066,6 +2611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~5.26.4":
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
@@ -2100,10 +2652,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wasm-feature-detect@npm:^1.2.11":
+  version: 1.8.0
+  resolution: "wasm-feature-detect@npm:1.8.0"
+  checksum: 2cb43e91bbf7aa7c121bc76b3133de3ab6dc4f482acc1d2dc46c528e8adb7a51c72df5c2aacf1d219f113c04efd1706f18274d5790542aa5dd49e0644e3ee665
+  languageName: node
+  linkType: hard
+
 "web-streams-polyfill@npm:^3.0.3":
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
   checksum: 64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -2137,6 +2713,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 
@@ -2185,5 +2772,19 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "yoctocolors-cjs@npm:2.1.2"
+  checksum: a0e36eb88fea2c7981eab22d1ba45e15d8d268626e6c4143305e2c1628fa17ebfaa40cd306161a8ce04c0a60ee0262058eab12567493d5eb1409780853454c6f
+  languageName: node
+  linkType: hard
+
+"zlibjs@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "zlibjs@npm:0.3.1"
+  checksum: 2d110bfcb0f8b8dbf225423f6556da9c5bca95c8b849c1218983676158a24b5cd0350357e0c4d504e27f8c7e18d471d9712576f35114a81a51bcf83453f02beb
   languageName: node
   linkType: hard


### PR DESCRIPTION
Steps:

Issue
- nav to pdf-issuer
- ts-node index.ts. Fill the details using CLI
- Pdf generated at /output

Verify
- nav to pdf-verifier
- npx tsx verifier.ts
- If tampering flow to be shown for demo, tamper the pdf with docx to pdf or use 3rd party tool.
- Change the file to check in verifier.ts and run `npx tsx verifier.ts` again. Gives the expected and tampered data.

TBD:

- Integrate with CORD, send the pdf's roll-no or any unique id as a registry-entry hash. Add the individual hashes as a blob. Create a profile for the issuer, registry.
- The metadata stored can be of human readable format, instead of current hashed one.
-  Do double verification, check the metadata stored on blob as well, instead of currently relying on pdf-metadata alone. 
- Have some templates for different style verifications.

Demo working video of the flow:
https://drive.google.com/file/d/15IbzBdQlrzUIrNduhUMZluZoaPBA1Ivb/view?usp=share_link

